### PR TITLE
Build Release instead of default Debug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN cmake \
     -Dbuild-prerequisites=OFF \
     -Dome-superbuild_BUILD_gtest=ON \
     -Dbuild-packages=ome-files \
+    -DCMAKE_BUILD_TYPE=Release \
     /git/ome-cmake-superbuild
 RUN make
 RUN make install


### PR DESCRIPTION
While running performance tests using this as a base image, I realized there was a slow performance when writing pixels.  @rleigh-codelibre suggested we were building a Debug build instead of Release.