### PR TITLE
OME Files 0.3.0 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install --upgrade pip
 RUN pip install Genshi
 
 WORKDIR /git
-RUN git clone --branch='master' https://github.com/ome/ome-cmake-superbuild.git
+RUN git clone --branch='v0.3.0' https://github.com/ome/ome-cmake-superbuild.git
 
 WORKDIR /build
 RUN cmake \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ RUN pip install Genshi
 
 WORKDIR /git
 RUN git clone --branch='master' https://github.com/ome/ome-cmake-superbuild.git
-RUN git clone --branch='master' https://github.com/ome/ome-common-cpp.git
-RUN git clone --branch='master' https://github.com/ome/ome-files-cpp.git
-RUN git clone --branch='master' https://github.com/ome/ome-model.git
 
 WORKDIR /build
 RUN cmake \


### PR DESCRIPTION
In preparation of the upcoming OME Files 0.3.0 release, this should download the sources to build the Docker images.

To test this PR, pull https://hub.docker.com/r/snoopycrimecop/ome-files-cpp-u1604/ and check that the version included is OME Files 0.3.0.

NB: one more commit or PR will be required to use the `ome-cmake-superbuild` tag once released.