### PR TITLE
Bump to OME Files C++ 0.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install Genshi
 RUN pip install Sphinx
 
 WORKDIR /git
-RUN git clone --branch='v0.3.0' https://github.com/ome/ome-cmake-superbuild.git
+RUN git clone --branch='v0.3.1' https://github.com/ome/ome-cmake-superbuild.git
 
 WORKDIR /build
 RUN cmake \


### PR DESCRIPTION
In preparation of the final benchmark run

To review this PR, wait for the completion of [the automated build](https://hub.docker.com/r/snoopycrimecop/ome-files-cpp-u1604/builds/brxfckqgzuzsazurt3uquq3/) then run 

```
$ docker pull snoopycrimecop/ome-files-cpp-u1604:master_merge_daily
$ docker run --rm -it snoopycrimecop/ome-files-cpp-u1604:master_merge_daily
```

and check `ome-files info --version` minimally