### PR TITLE
Bump version of ome-cmake-superbuild to 0.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install Genshi
 RUN pip install Sphinx
 
 WORKDIR /git
-RUN git clone --branch='v0.3.1' https://github.com/ome/ome-cmake-superbuild.git
+RUN git clone --branch='v0.3.2' https://github.com/ome/ome-cmake-superbuild.git
 
 WORKDIR /build
 RUN cmake \


### PR DESCRIPTION
With this commit, the image generated by the Dockerfile script should install OME Files C++ 0.3.2

To test this PR use the merge build from https://hub.docker.com/r/snoopycrimecop/ome-files-cpp-u1604/ and check that

```
docker run --rm -it snoopycrimecop/ome-files-cpp-u1604:master_merge_daily
```

contains the correct version of `ome-files`