### PR TITLE
Install locales and set up an UTF-8 environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,14 @@ RUN apt-get update && apt-get -y install \
   libpng-dev \
   libgtest-dev \
   libtiff5-dev \
-  python-pip
+  locales \
+  python-pip \
+  && locale-gen en_US.UTF-8
+
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    TERM=xterm
+
 RUN pip install --upgrade pip
 RUN pip install Genshi
 RUN pip install Sphinx

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ RUN apt-get update && apt-get -y install \
   python-pip \
   && locale-gen en_US.UTF-8
 
-ENV LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    TERM=xterm
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 RUN pip install --upgrade pip
 RUN pip install Genshi


### PR DESCRIPTION
See also https://github.com/tianon/docker-brew-ubuntu-core/issues/82
The locales package has been removed from the base ubuntu image. This commit
is setting up an UTF-8 environment in the base OME Files C++ Docker image so
that consumers do not have to workaround it.

To test this PR, download the daily merge image, execute it and check the locale is properly set

```
docker pull snoopycrimecop/ome-files-cpp-u1604:master_merge_daily
docker run --rm -it snoopycrimecop/ome-files-cpp-u1604:master_merge_daily
% locale
```