### PR TITLE
Update for ome-files 0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,11 @@ RUN pip install Genshi
 RUN pip install Sphinx
 
 WORKDIR /git
-RUN git clone --branch='v5.4.1' https://github.com/ome/ome-common-cpp.git
-RUN git clone --branch='v5.5.3' https://github.com/ome/ome-model.git
-RUN git clone --branch='master' https://github.com/ome/ome-files-cpp.git
-RUN git clone --branch='v5.4.1' https://github.com/ome/ome-qtwidgets.git
-RUN git clone --branch='v0.3.2' https://github.com/ome/ome-cmake-superbuild.git
+RUN git clone --branch='v5.4.2' https://github.com/ome/ome-common-cpp.git
+RUN git clone --branch='v5.5.6' https://github.com/ome/ome-model.git
+RUN git clone --branch='v0.4.0' https://github.com/ome/ome-files-cpp.git
+RUN git clone --branch='v5.4.2' https://github.com/ome/ome-qtwidgets.git
+RUN git clone --branch='v0.4.0' https://github.com/ome/ome-cmake-superbuild.git
 
 WORKDIR /build
 RUN cmake \


### PR DESCRIPTION
Updates the Dockerfile to install version 0.4.0.

To test:

* check that the [automated build](https://hub.docker.com/r/snoopycrimecop/ome-files-cpp-u1604/builds/bk2cswxdhlje5mz84ubnqsy/) went fine
* check that the Docker image works and provides ome-files version 0.4.0. Mininally:

```
% docker pull snoopycrimecop/ome-files-cpp-u1604:master_merge_daily
% docker run --rm snoopycrimecop/ome-files-cpp-u1604:master_merge_daily ome-files --version
ome-files (OME Files) 0.4.0
[...]
```